### PR TITLE
Decoupling of simulation box and initial particle distribution.

### DIFF
--- a/docs/documentation/input_file.rst
+++ b/docs/documentation/input_file.rst
@@ -135,10 +135,14 @@ parameters defined in previous sections. The second instance is the value of the
 - ``random_reject`` for a uniform spatial distribution but with a minimum distance between particles
 - ``halton``
 
-Next we define the ``boundary_conditions`` of our simulation. At the moment Sarkas supports only ``periodic`` boundary
-conditions. 
+Next we define the ``boundary_conditions`` of our simulation. At the moment Sarkas supports only ``periodic`` and
+``absorbing`` boundary conditions. 
 Future implementations of Sarkas accepting open and mixed boundary conditions will be available in the future.
 We accept pull request :) !
+
+By specifying ``Lx``, ``Ly`` and ``Lz`` the simulation box can be specified explicitly and expanded with respect
+to the initial particle distribution. This moves the walls where boundary conditions are applied away from the
+initial particle volume.
 
 Input/Output
 ------------

--- a/sarkas/core.py
+++ b/sarkas/core.py
@@ -27,6 +27,9 @@ class Parameters:
     box_volume : float
         Volume of simulation box.
 
+    pbox_volume : float
+        Volume of initial particle box.
+
     dimensions : int
         Number of non-zero dimensions. Default = 3.
 
@@ -86,6 +89,24 @@ class Parameters:
 
     e3 : float
         Unit vector in the :math:`z` direction.
+
+    LPx : float
+        Initial particle box length in the :math:`x` direction.
+
+    LPy : float
+        Initial particle box length in the :math:`y` direction.
+
+    LPz : float
+        Initial particle box length in the :math:`z` direction.
+
+    ep1 : float
+        Unit vector of the initial particle box in the :math:`x` direction.
+
+    ep2 : float
+        Unit vector of the initial particle box in the :math:`y` direction.
+
+    ep3 : float
+        Unit vector of the initial particle box in the :math:`z` direction.
 
     input_file : str
         YAML Input file with all the simulation's parameters.
@@ -181,8 +202,13 @@ class Parameters:
         self.Lx = 0.0
         self.Ly = 0.0
         self.Lz = 0.0
+        self.LPx = 0.0
+        self.LPy = 0.0
+        self.LPz = 0.0
         self.box_lengths = np.zeros(3)
+        self.pbox_lengths = np.zeros(3)
         self.box_volume = 0.0
+        self.pbox_volume = 0.0
         self.dimensions = 3
         self.J2erg = 1.0e+7  # erg/J
         self.eps0 = const.epsilon_0
@@ -453,19 +479,25 @@ class Parameters:
         # Wigner-Seitz radius calculated from the total number density
         self.a_ws = (3.0 / (4.0 * np.pi * self.total_num_density)) ** (1. / 3.)
 
-        # Calculate simulation's box parameters
+        # Calculate initial particle's and simulation's box parameters
         if self.np_per_side:
             msg = "Number of particles per dimension does not match total number of particles."
             assert int(np.prod(self.np_per_side)) == self.total_num_ptcls, msg
 
-            self.Lx = self.a_ws * self.np_per_side[0] * (4.0 * np.pi / 3.0) ** (1.0 / 3.0)
-            self.Ly = self.a_ws * self.np_per_side[1] * (4.0 * np.pi / 3.0) ** (1.0 / 3.0)
-            self.Lz = self.a_ws * self.np_per_side[2] * (4.0 * np.pi / 3.0) ** (1.0 / 3.0)
+            self.LPx = self.a_ws * self.np_per_side[0] * (4.0 * np.pi / 3.0) ** (1.0 / 3.0)
+            self.LPy = self.a_ws * self.np_per_side[1] * (4.0 * np.pi / 3.0) ** (1.0 / 3.0)
+            self.LPz = self.a_ws * self.np_per_side[2] * (4.0 * np.pi / 3.0) ** (1.0 / 3.0)
         else:
-            self.Lx = self.a_ws * (4.0 * np.pi * self.total_num_ptcls / 3.0) ** (1.0 / 3.0)
-            self.Ly = self.a_ws * (4.0 * np.pi * self.total_num_ptcls / 3.0) ** (1.0 / 3.0)
-            self.Lz = self.a_ws * (4.0 * np.pi * self.total_num_ptcls / 3.0) ** (1.0 / 3.0)
+            self.LPx = self.a_ws * (4.0 * np.pi * self.total_num_ptcls / 3.0) ** (1.0 / 3.0)
+            self.LPy = self.a_ws * (4.0 * np.pi * self.total_num_ptcls / 3.0) ** (1.0 / 3.0)
+            self.LPz = self.a_ws * (4.0 * np.pi * self.total_num_ptcls / 3.0) ** (1.0 / 3.0)
 
+        if self.Lx == 0 or self.Ly == 0 or self.Lz == 0:
+            self.Lx = self.LPx
+            self.Ly = self.LPy
+            self.Lz = self.LPz
+
+        self.pbox_lengths = np.array([self.LPx, self.LPy, self.LPz])  # initial particle box length vector
         self.box_lengths = np.array([self.Lx, self.Ly, self.Lz])  # box length vector
 
         # Dev Note: The following are useful for future geometries
@@ -473,7 +505,12 @@ class Parameters:
         self.e2 = np.array([0.0, self.Ly, 0.0])
         self.e3 = np.array([0.0, 0.0, self.Lz])
 
+        self.ep1 = np.array([self.LPx, 0.0, 0.0])
+        self.ep2 = np.array([0.0, self.LPy, 0.0])
+        self.ep3 = np.array([0.0, 0.0, self.LPz])
+
         self.box_volume = abs(np.dot(np.cross(self.e1, self.e2), self.e3))
+        self.pbox_volume = abs(np.dot(np.cross(self.ep1, self.ep2), self.ep3))
 
         self.dimensions = np.count_nonzero(self.box_lengths)  # no. of dimensions
         # Transform the list of species names into a np.array
@@ -510,7 +547,7 @@ class Parameters:
             Flag for printing electron properties. Default = True
 
         """
-        print("\nSIMULATION BOX:")
+        print("\nSIMULATION AND INITIAL PARTICLE BOX:")
         print('Units: ', self.units)
         print('Wigner-Seitz radius = {:.6e} '.format(self.a_ws), end='')
         print("[cm]" if self.units == "cgs" else "[m]")
@@ -530,6 +567,23 @@ class Parameters:
             end='')
         print("[cm]" if self.units == "cgs" else "[m]")
         print("Box Volume = {:.6e} ".format(self.box_volume), end='')
+        print("[cm^3]" if self.units == "cgs" else "[m^3]")
+
+        print('Initial particle box side along x axis = {:.6e} a_ws = {:.6e} '.format(
+            self.pbox_lengths[0] / self.a_ws, self.pbox_lengths[0]),
+            end='')
+        print("[cm]" if self.units == "cgs" else "[m]")
+
+        print('Initial particle box side along y axis = {:.6e} a_ws = {:.6e} '.format(
+            self.pbox_lengths[1] / self.a_ws, self.pbox_lengths[1]),
+            end='')
+        print("[cm]" if self.units == "cgs" else "[m]")
+
+        print('Initial particle box side along z axis = {:.6e} a_ws = {:.6e} '.format(
+            self.pbox_lengths[2] / self.a_ws, self.pbox_lengths[2]),
+            end='')
+        print("[cm]" if self.units == "cgs" else "[m]")
+        print("Initial particle box Volume = {:.6e} ".format(self.pbox_volume), end='')
         print("[cm^3]" if self.units == "cgs" else "[m^3]")
 
         print('Boundary conditions: {}'.format(self.boundary_conditions))
@@ -607,6 +661,9 @@ class Particles:
     box_lengths : numpy.ndarray
         Box sides' lengths.
 
+    pbox_lengths : numpy.ndarray
+        Initial particle box sides' lengths.
+
     masses : numpy.ndarray
         Mass of each particle. Shape = (``total_num_ptcls``).
 
@@ -660,6 +717,7 @@ class Particles:
         self.prod_dump_dir = None
         self.eq_dump_dir = None
         self.box_lengths = None
+        self.pbox_lengths = None
         self.total_num_ptcls = None
         self.num_species = None
         self.species_num = None
@@ -711,6 +769,7 @@ class Particles:
         self.prod_dump_dir = params.prod_dump_dir
         self.eq_dump_dir = params.eq_dump_dir
         self.box_lengths = np.copy(params.box_lengths)
+        self.pbox_lengths = np.copy(params.pbox_lengths)
         self.total_num_ptcls = params.total_num_ptcls
         self.num_species = params.num_species
         self.species_num = np.copy(params.species_num)
@@ -796,7 +855,7 @@ class Particles:
             self.halton_reject(params.load_halton_bases, params.load_rejection_radius)
 
         elif params.load_method in ['uniform', 'random_no_reject']:
-            self.pos = self.uniform_no_reject([0.0, 0.0, 0.0], params.box_lengths)
+            self.pos = self.uniform_no_reject(params.box_lengths/2 - params.pbox_lengths/2, params.box_lengths/2 + params.pbox_lengths/2)
 
         else:
             raise AttributeError('Incorrect particle placement scheme specified.')
@@ -966,8 +1025,9 @@ class Particles:
         -----
         Author: Luke Stanek
         Date Created: 5/6/19
-        Date Updated: 6/2/19
+        Date Updated: 6/2/19, 9/7/21
         Updates: Added to S_init_schemes.py for Sarkas import
+                 Place lattice according to pbox parameters into center of simulation box (PWS)
         """
 
         # Check if perturbation is below maximum allowed. If not, default to maximum perturbation.
@@ -987,14 +1047,14 @@ class Particles:
             print('\nWARNING: Total number of particles requested is not a perfect cube.')
             print('Initializing with {} particles.'.format(int(part_per_side ** 3)))
 
-        dx_lattice = self.box_lengths[0] / (self.total_num_ptcls ** (1. / 3.))  # Lattice spacing
-        dz_lattice = self.box_lengths[1] / (self.total_num_ptcls ** (1. / 3.))  # Lattice spacing
-        dy_lattice = self.box_lengths[2] / (self.total_num_ptcls ** (1. / 3.))  # Lattice spacing
+        dx_lattice = self.pbox_lengths[0] / (self.total_num_ptcls ** (1. / 3.))  # Lattice spacing
+        dz_lattice = self.pbox_lengths[1] / (self.total_num_ptcls ** (1. / 3.))  # Lattice spacing
+        dy_lattice = self.pbox_lengths[2] / (self.total_num_ptcls ** (1. / 3.))  # Lattice spacing
 
         # Create x, y, and z position arrays
-        x = np.arange(0, self.box_lengths[0], dx_lattice) + 0.5 * dx_lattice
-        y = np.arange(0, self.box_lengths[1], dy_lattice) + 0.5 * dy_lattice
-        z = np.arange(0, self.box_lengths[2], dz_lattice) + 0.5 * dz_lattice
+        x = np.arange(0, self.pbox_lengths[0], dx_lattice) + 0.5 * dx_lattice
+        y = np.arange(0, self.pbox_lengths[1], dy_lattice) + 0.5 * dy_lattice
+        z = np.arange(0, self.pbox_lengths[2], dz_lattice) + 0.5 * dz_lattice
 
         # Create a lattice with appropriate x, y, and z values based on arange
         X, Y, Z = np.meshgrid(x, y, z)
@@ -1005,13 +1065,13 @@ class Particles:
         Z += self.rnd_gen.uniform(-0.5, 0.5, np.shape(Z)) * perturb * dz_lattice
 
         # Flatten the meshgrid values for plotting and computation
-        self.pos[:, 0] = X.ravel()
-        self.pos[:, 1] = Y.ravel()
-        self.pos[:, 2] = Z.ravel()
+        self.pos[:, 0] = X.ravel() + self.box_lengths[0]/2 - self.pbox_lengths[0]/2
+        self.pos[:, 1] = Y.ravel() + self.box_lengths[1]/2 - self.pbox_lengths[1]/2
+        self.pos[:, 2] = Z.ravel() + self.box_lengths[2]/2 - self.pbox_lengths[2]/2
 
     def random_reject(self, r_reject):
         """
-        Place particles by sampling a uniform distribution from 0 to L (the box length)
+        Place particles by sampling a uniform distribution from 0 to LP (the initial particle box length)
         and uses a rejection radius to avoid placing particles to close to each other.
 
         Parameters
@@ -1023,8 +1083,8 @@ class Particles:
         -----
         Author: Luke Stanek
         Date Created: 5/6/19
-        Date Updated: N/A
-        Updates: N/A
+        Date Updated: 9/7/21
+        Updates: Place initial particles according to pbox parameters into the simulation box center (PWS)
 
         """
 
@@ -1034,9 +1094,9 @@ class Particles:
         z = np.array([])
 
         # Set first x, y, and z positions
-        x_new = self.rnd_gen.uniform(0, self.box_lengths[0])
-        y_new = self.rnd_gen.uniform(0, self.box_lengths[1])
-        z_new = self.rnd_gen.uniform(0, self.box_lengths[2])
+        x_new = self.rnd_gen.uniform(0, self.pbox_lengths[0])
+        y_new = self.rnd_gen.uniform(0, self.pbox_lengths[1])
+        z_new = self.rnd_gen.uniform(0, self.pbox_lengths[2])
 
         # Append to arrays
         x = np.append(x, x_new)
@@ -1052,9 +1112,9 @@ class Particles:
         while i < self.total_num_ptcls - 1:
 
             # Set x, y, and z positions
-            x_new = self.rnd_gen.uniform(0.0, self.box_lengths[0])
-            y_new = self.rnd_gen.uniform(0.0, self.box_lengths[1])
-            z_new = self.rnd_gen.uniform(0.0, self.box_lengths[2])
+            x_new = self.rnd_gen.uniform(0.0, self.pbox_lengths[0])
+            y_new = self.rnd_gen.uniform(0.0, self.pbox_lengths[1])
+            z_new = self.rnd_gen.uniform(0.0, self.pbox_lengths[2])
 
             # Check if particle was place too close relative to all other current particles
             for j in range(len(x)):
@@ -1068,20 +1128,20 @@ class Particles:
                 z_diff = z_new - z[j]
 
                 # periodic condition applied for minimum image
-                if x_diff < - self.box_lengths[0] / 2:
-                    x_diff += self.box_lengths[0]
-                if x_diff > self.box_lengths[0] / 2:
-                    x_diff -= self.box_lengths[0]
+                if x_diff < - self.pbox_lengths[0] / 2:
+                    x_diff += self.pbox_lengths[0]
+                if x_diff > self.pbox_lengths[0] / 2:
+                    x_diff -= self.pbox_lengths[0]
 
-                if y_diff < - self.box_lengths[1] / 2:
-                    y_diff += self.box_lengths[1]
-                if y_diff > self.box_lengths[1] / 2:
-                    y_diff -= self.box_lengths[1]
+                if y_diff < - self.pbox_lengths[1] / 2:
+                    y_diff += self.pbox_lengths[1]
+                if y_diff > self.pbox_lengths[1] / 2:
+                    y_diff -= self.pbox_lengths[1]
 
-                if z_diff < -self.box_lengths[2] / 2:
-                    z_diff += self.box_lengths[2]
-                if z_diff > self.box_lengths[2] / 2:
-                    z_diff -= self.box_lengths[2]
+                if z_diff < -self.pbox_lengths[2] / 2:
+                    z_diff += self.pbox_lengths[2]
+                if z_diff > self.pbox_lengths[2] / 2:
+                    z_diff -= self.pbox_lengths[2]
 
                 # Compute distance
                 r = np.sqrt(x_diff ** 2 + y_diff ** 2 + z_diff ** 2)
@@ -1103,13 +1163,13 @@ class Particles:
                 i += 1
                 cntr_total += 1
 
-        self.pos[:, 0] = x
-        self.pos[:, 1] = y
-        self.pos[:, 2] = z
+        self.pos[:, 0] = x + self.box_lengths[0]/2 - self.pbox_lengths[0]/2
+        self.pos[:, 1] = y + self.box_lengths[1]/2 - self.pbox_lengths[1]/2
+        self.pos[:, 2] = z + self.box_lengths[2]/2 - self.pbox_lengths[2]/2
 
     def halton_reject(self, bases, r_reject):
         """
-        Place particles according to a Halton sequence from 0 to L (the box length)
+        Place particles according to a Halton sequence from 0 to LP (the initial particle box length)
         and uses a rejection radius to avoid placing particles to close to each other.
 
         Parameters
@@ -1125,8 +1185,8 @@ class Particles:
         -----
         Author: Luke Stanek
         Date Created: 5/6/19
-        Date Updated: N/A
-        Updates: N/A
+        Date Updated: 9/7/21
+        Updates: Place initial particles according to pbox parameters into the simulation box center (PWS)
 
         """
 
@@ -1157,7 +1217,7 @@ class Particles:
                 f1 /= b1
                 r1 += f1 * (n % int(b1))
                 n = np.floor(n / b1)
-            x_new = self.box_lengths[0] * r1  # new x value
+            x_new = self.pbox_lengths[0] * r1  # new x value
 
             # Determine y coordinate
             f2 = 1
@@ -1166,7 +1226,7 @@ class Particles:
                 f2 /= b2
                 r2 += f2 * (m % int(b2))
                 m = np.floor(m / b2)
-            y_new = self.box_lengths[1] * r2  # new y value
+            y_new = self.pbox_lengths[1] * r2  # new y value
 
             # Determine z coordinate
             f3 = 1
@@ -1175,7 +1235,7 @@ class Particles:
                 f3 /= b3
                 r3 += f3 * (p % int(b3))
                 p = np.floor(p / b3)
-            z_new = self.box_lengths[2] * r3  # new z value
+            z_new = self.pbox_lengths[2] * r3  # new z value
 
             # Check if particle was place too close relative to all other current particles
             for j in range(len(x)):
@@ -1189,20 +1249,20 @@ class Particles:
                 z_diff = z_new - z[j]
 
                 # Periodic condition applied for minimum image
-                if x_diff < - self.box_lengths[0] / 2:
-                    x_diff = x_diff + self.box_lengths[0]
-                if x_diff > self.box_lengths[0] / 2:
-                    x_diff = x_diff - self.box_lengths[0]
+                if x_diff < - self.pbox_lengths[0] / 2:
+                    x_diff = x_diff + self.pbox_lengths[0]
+                if x_diff > self.pbox_lengths[0] / 2:
+                    x_diff = x_diff - self.pbox_lengths[0]
 
-                if y_diff < -self.box_lengths[1] / 2:
-                    y_diff = y_diff + self.box_lengths[1]
-                if y_diff > self.box_lengths[1] / 2:
-                    y_diff = y_diff - self.box_lengths[1]
+                if y_diff < -self.pbox_lengths[1] / 2:
+                    y_diff = y_diff + self.pbox_lengths[1]
+                if y_diff > self.pbox_lengths[1] / 2:
+                    y_diff = y_diff - self.pbox_lengths[1]
 
-                if z_diff < -self.box_lengths[2] / 2:
-                    z_diff = z_diff + self.box_lengths[2]
-                if z_diff > self.box_lengths[2] / 2:
-                    z_diff = z_diff - self.box_lengths[2]
+                if z_diff < -self.pbox_lengths[2] / 2:
+                    z_diff = z_diff + self.pbox_lengths[2]
+                if z_diff > self.pbox_lengths[2] / 2:
+                    z_diff = z_diff - self.pbox_lengths[2]
 
                 # Compute distance
                 r = np.sqrt(x_diff ** 2 + y_diff ** 2 + z_diff ** 2)
@@ -1223,9 +1283,9 @@ class Particles:
                 k += 1  # Increment Halton counter
                 i += 1  # Increment particle number
 
-        self.pos[:, 0] = x
-        self.pos[:, 1] = y
-        self.pos[:, 2] = z
+        self.pos[:, 0] = x + self.box_lengths[0]/2 - self.pbox_lengths[0]/2
+        self.pos[:, 1] = y + self.box_lengths[1]/2 - self.pbox_lengths[1]/2
+        self.pos[:, 2] = z + self.box_lengths[2]/2 - self.pbox_lengths[2]/2
 
     def kinetic_temperature(self):
         """

--- a/sarkas/core.py
+++ b/sarkas/core.py
@@ -492,9 +492,11 @@ class Parameters:
             self.LPy = self.a_ws * (4.0 * np.pi * self.total_num_ptcls / 3.0) ** (1.0 / 3.0)
             self.LPz = self.a_ws * (4.0 * np.pi * self.total_num_ptcls / 3.0) ** (1.0 / 3.0)
 
-        if self.Lx == 0 or self.Ly == 0 or self.Lz == 0:
+        if self.Lx == 0:
             self.Lx = self.LPx
+        if self.Ly == 0:
             self.Ly = self.LPy
+        if self.Lz == 0:
             self.Lz = self.LPz
 
         self.pbox_lengths = np.array([self.LPx, self.LPy, self.LPz])  # initial particle box length vector

--- a/sarkas/potentials/core.py
+++ b/sarkas/potentials/core.py
@@ -99,7 +99,9 @@ class Potential:
         self.force_error = None
         self.measure = False
         self.box_lengths = 0.0
+        self.pbox_lengths = 0.0
         self.box_volume = 0.0
+        self.pbox_volume = 0.0
         self.fourpie0 = 0.0
         self.QFactor = 0.0
         self.total_net_charge = 0.0
@@ -215,7 +217,9 @@ class Potential:
 
         # Copy needed parameters
         self.box_lengths = np.copy(params.box_lengths)
+        self.pbox_lengths = np.copy(params.pbox_lengths)
         self.box_volume = params.box_volume
+        self.pbox_volume = params.pbox_volume
         self.fourpie0 = params.fourpie0
         self.QFactor = params.QFactor
         self.total_net_charge = params.total_net_charge

--- a/sarkas/potentials/coulomb.py
+++ b/sarkas/potentials/coulomb.py
@@ -1,4 +1,4 @@
-""" 
+"""
 Module for handling Coulomb interaction
 """
 
@@ -39,12 +39,12 @@ def update_params(potential, params):
     # PP force error calculation. Note that the equation was derived for a single component plasma.
     alpha_times_rcut = - (potential.pppm_alpha_ewald * potential.rc) ** 2
     params.pppm_pp_err = 2.0 * np.exp(alpha_times_rcut) / np.sqrt(potential.rc)
-    params.pppm_pp_err *= np.sqrt(params.total_num_ptcls) * params.a_ws ** 2 / np.sqrt(params.box_volume)
+    params.pppm_pp_err *= np.sqrt(params.total_num_ptcls) * params.a_ws ** 2 / np.sqrt(params.pbox_volume)
 
 
 @njit
 def coulomb_force_pppm(r, pot_matrix):
-    """ 
+    """
     Calculate Potential and Force between two particles when the P3M algorithm is chosen.
 
     Parameters
@@ -59,10 +59,10 @@ def coulomb_force_pppm(r, pot_matrix):
     -------
     U_s_r : float
         Potential value.
-                
+
     fr : float
-        Force between two particles. 
-    
+        Force between two particles.
+
     """
 
     alpha = pot_matrix[1]  # Ewald parameter alpha

--- a/sarkas/potentials/egs.py
+++ b/sarkas/potentials/egs.py
@@ -95,21 +95,21 @@ def update_params(potential, params):
     potential.force = egs_force
     params.force_error = np.sqrt(twopi / params.lambda_TF) * np.exp(-potential.rc / params.lambda_TF)
     # Renormalize
-    params.force_error *= params.a_ws ** 2 * np.sqrt(params.total_num_ptcls / params.box_volume)
+    params.force_error *= params.a_ws ** 2 * np.sqrt(params.total_num_ptcls / params.pbox_volume)
 
 
 @njit
 def egs_force(r, pot_matrix):
-    """ 
+    """
     Calculates Potential and force between particles using the EGS Potential.
-    
+
     Parameters
     ----------
     r : float
         Particles' distance.
 
     pot_matrix : array
-        EGS potential parameters. 
+        EGS potential parameters.
 
     Return
     ------

--- a/sarkas/potentials/lennardjones.py
+++ b/sarkas/potentials/lennardjones.py
@@ -48,18 +48,18 @@ def update_params(potential, params):
     deriv_exp = (potential.powers[0] + 1)
     params.force_error = np.sqrt(np.pi * sigma2 ** potential.powers[0])
     params.force_error /= np.sqrt(deriv_exp * potential.rc ** deriv_exp)
-    params.force_error *= np.sqrt(params.total_num_ptcls / params.box_volume) * params.a_ws ** 2
+    params.force_error *= np.sqrt(params.total_num_ptcls / params.pbox_volume) * params.a_ws ** 2
 
 
 @nb.njit
 def lj_force(r, pot_matrix_ij):
     """
     Calculates the PP force between particles using Lennard-Jones Potential.
-    
+
     Parameters
     ----------
     pot_matrix_ij : array
-        LJ potential parameters. 
+        LJ potential parameters.
 
     r : float
         Particles' distance.
@@ -80,7 +80,7 @@ def lj_force(r, pot_matrix_ij):
     pot_matrix[1] = sigmas
     pot_matrix[2] = highest power
     pot_matrix[3] = lowest power
-    
+
     """
 
     epsilon = pot_matrix_ij[0]

--- a/sarkas/potentials/moliere.py
+++ b/sarkas/potentials/moliere.py
@@ -38,21 +38,21 @@ def update_params(potential, params):
     params.force_error = np.sqrt(2.0 * np.pi / potential.screening_lengths.min()) \
                     * np.exp(- potential.rc / potential.screening_lengths.min())
     # Renormalize
-    params.force_error *= params.a_ws ** 2 * np.sqrt(params.total_num_ptcls / params.box_volume)
+    params.force_error *= params.a_ws ** 2 * np.sqrt(params.total_num_ptcls / params.pbox_volume)
 
 
 @nb.njit
 def moliere_force(r, pot_matrix):
-    """ 
+    """
     Calculates the PP force between particles using the Moliere Potential.
-    
+
     Parameters
     ----------
     r : float
         Particles' distance.
 
     pot_matrix : numpy.ndarray
-        Moliere potential parameters. 
+        Moliere potential parameters.
 
 
     Returns

--- a/sarkas/potentials/qsp.py
+++ b/sarkas/potentials/qsp.py
@@ -108,7 +108,7 @@ def update_params(potential, params):
         # Calculate the PP Force error from the e-e diffraction term only.
         params.pppm_pp_err = np.sqrt(two_pi * potential.matrix[1, 0, 0])
         params.pppm_pp_err *= np.exp(- potential.rc * potential.matrix[1, 0, 0])
-        params.pppm_pp_err *= params.a_ws ** 2 * np.sqrt(params.total_num_ptcls / params.box_volume)
+        params.pppm_pp_err *= params.a_ws ** 2 * np.sqrt(params.total_num_ptcls / params.box_volume) # TODO: Rather use pbox_volume here?
 
     elif potential.qsp_type.lower() == "kelbg":
         potential.force = kelbg_force

--- a/sarkas/potentials/qsp.py
+++ b/sarkas/potentials/qsp.py
@@ -108,7 +108,7 @@ def update_params(potential, params):
         # Calculate the PP Force error from the e-e diffraction term only.
         params.pppm_pp_err = np.sqrt(two_pi * potential.matrix[1, 0, 0])
         params.pppm_pp_err *= np.exp(- potential.rc * potential.matrix[1, 0, 0])
-        params.pppm_pp_err *= params.a_ws ** 2 * np.sqrt(params.total_num_ptcls / params.box_volume) # TODO: Rather use pbox_volume here?
+        params.pppm_pp_err *= params.a_ws ** 2 * np.sqrt(params.total_num_ptcls / params.pbox_volume)
 
     elif potential.qsp_type.lower() == "kelbg":
         potential.force = kelbg_force
@@ -119,7 +119,7 @@ def update_params(potential, params):
 
 @njit
 def deutsch_force(r, pot_matrix):
-    """ 
+    """
     Calculate Deutsch QSP Force between two particles.
 
     Parameters
@@ -139,7 +139,7 @@ def deutsch_force(r, pot_matrix):
     -------
     U : float
         Potential.
-                
+
     force : float
         Force between two particles.
 
@@ -176,7 +176,7 @@ def deutsch_force(r, pot_matrix):
 
 @njit
 def kelbg_force(r, pot_matrix):
-    """ 
+    """
     Calculates the QSP Force between two particles when the P3M algorithm is chosen.
 
     Parameters
@@ -196,10 +196,10 @@ def kelbg_force(r, pot_matrix):
     -------
     U : float
         Potential.
-                
+
     force : float
         Force between two particles.
-    
+
     """
 
     A = pot_matrix[0]

--- a/sarkas/potentials/yukawa.py
+++ b/sarkas/potentials/yukawa.py
@@ -8,7 +8,7 @@ import math as mt
 
 @njit
 def yukawa_force_pppm(r, pot_matrix):
-    """ 
+    """
     Calculates Potential and Force between two particles when the P3M algorithm is chosen.
 
     Parameters
@@ -23,7 +23,7 @@ def yukawa_force_pppm(r, pot_matrix):
     -------
     U_s_r : float
         Potential value
-                
+
     fr : float
         Force between two particles calculated using eq.(22) in Ref. [Dharuman2017] .
 
@@ -53,7 +53,7 @@ def yukawa_force_pppm(r, pot_matrix):
 
 @njit
 def yukawa_force(r, pot_matrix):
-    """ 
+    """
     Calculates Potential and Force between two particles.
 
     Parameters
@@ -68,10 +68,10 @@ def yukawa_force(r, pot_matrix):
     -------
     U : float
         Potential.
-                
+
     force : float
         Force between two particles.
-    
+
     """
     U = pot_matrix[0] * np.exp(-pot_matrix[1] * r) / r
     force = U * (1 / r + pot_matrix[1])
@@ -109,7 +109,7 @@ def update_params(potential, params):
         # Force error calculated from eq.(43) in Ref.[1]_
         params.force_error = np.sqrt( twopi / params.lambda_TF) * np.exp(- potential.rc / params.lambda_TF)
         # Renormalize
-        params.force_error *= params.a_ws ** 2 * np.sqrt(params.total_num_ptcls / params.box_volume)
+        params.force_error *= params.a_ws ** 2 * np.sqrt(params.total_num_ptcls / params.pbox_volume)
     elif potential.method == "P3M":
         potential.force = yukawa_force_pppm
         potential.matrix[2, :, :] = potential.pppm_alpha_ewald
@@ -117,4 +117,4 @@ def update_params(potential, params):
         kappa_over_alpha = - 0.25 * (potential.matrix[1, 0, 0] / potential.matrix[2, 0, 0]) ** 2
         alpha_times_rcut = - (potential.matrix[2, 0, 0] * potential.rc) ** 2
         params.pppm_pp_err = 2.0 * np.exp(kappa_over_alpha + alpha_times_rcut) / np.sqrt(potential.rc)
-        params.pppm_pp_err *= np.sqrt(params.total_num_ptcls) * params.a_ws ** 2 / np.sqrt(params.box_volume)
+        params.pppm_pp_err *= np.sqrt(params.total_num_ptcls) * params.a_ws ** 2 / np.sqrt(params.pbox_volume)

--- a/sarkas/time_evolution/integrators.py
+++ b/sarkas/time_evolution/integrators.py
@@ -47,6 +47,9 @@ class Integrator:
     box_lengths: numpy.ndarray
         Length of each box side.
 
+    pbox_lengths: numpy.ndarray
+        Initial particle box sides' lengths.
+
     verbose: bool
         Verbose output flag.
 
@@ -79,6 +82,7 @@ class Integrator:
         self.update = None
         self.species_num = None
         self.box_lengths = None
+        self.pbox_lengths = None
         self.boundary_conditions = None
         self.verbose = False
         self.supported_boundary_conditions = ['periodic', 'absorbing']
@@ -121,6 +125,7 @@ class Integrator:
 
         """
         self.box_lengths = np.copy(params.box_lengths)
+        self.pbox_lengths = np.copy(params.pbox_lengths)
         self.kB = params.kB
         self.species_num = np.copy(params.species_num)
         self.boundary_conditions = params.boundary_conditions


### PR DESCRIPTION
Decoupling of the simulation box (determined by Lx, Ly and Lz) from the initial particle distribution (determined by LPx, LPy and LPz) placed in the center of the simulation box. This allows expanding the simulation box by setting Lx, Ly, Lz in the config YAML file to simulate plasmas in a box larger than the initial particle distribution. This is particularly useful for systems where finitie size effects are relevant. By default, if no Lx, Ly, Lz are specified the simulation box is as big as the initial particle distribution.