### PR TITLE
Add an initial test using pytest

### DIFF
--- a/sarkas/utilities/tests/test_io.py
+++ b/sarkas/utilities/tests/test_io.py
@@ -1,0 +1,15 @@
+import pytest
+from sarkas.utilities.io import alpha_to_int
+
+
+@pytest.mark.parametrize(
+    "argument, expected_outcome",
+    [
+        ("1", 1),
+        ("0", 0),
+        ("12345", 12345),
+    ],
+)
+def test_alpha_to_int(argument, expected_outcome):
+    actual_outcome = alpha_to_int(argument)
+    assert actual_outcome == expected_outcome


### PR DESCRIPTION
Following a discussion with @lucianogsilvestri at the PlasmaPy meeting today, I added an example test using [pytest](https://docs.pytest.org/). I used [`@pytest.mark.parametrize`](https://docs.pytest.org/en/6.2.x/parametrize.html?highlight=parametrize#pytest-mark-parametrize) which lets us repeat a test with different values.  After running `pip install pytest`, you can run this test by running ``pytest`` (in a directory in the repository that contains the `tests` sub-directory).

I did notice that `alpha_to_int` doesn't work for negative numbers, but didn't want to make any changes to the API in this pull request.