### PR TITLE
Fixed bugs when using pp algorithm (force, Coulomb)

### DIFF
--- a/docs/examples/Ultrafast_EC/input_files/uec.yaml
+++ b/docs/examples/Ultrafast_EC/input_files/uec.yaml
@@ -55,6 +55,3 @@ IO:
 Observables:
   - Thermodynamics:
       phase: production
-
-  - RadialDistributionFunction:
-      no_bins: 51

--- a/sarkas/potentials/coulomb.py
+++ b/sarkas/potentials/coulomb.py
@@ -48,7 +48,7 @@ def update_params(potential, params):
         for j, q2 in enumerate(params.species_charges):
             potential.matrix[0, i, j] = q1 * q2 / params.fourpie0
 
-    if potential.method == "PP":
+    if potential.method == "pp":
         potential.matrix[2, :, :] = potential.a_rs
         potential.force = coulomb_force
         params.force_error = 0.0  # TODO: Implement force error in PP case

--- a/sarkas/potentials/force_pp.py
+++ b/sarkas/potentials/force_pp.py
@@ -96,6 +96,7 @@ def update_0D(pos, id_ij, mass_ij, Lv, rc, potential_matrix, force, measure, rdf
                 p_matrix = potential_matrix[:, id_i, id_j]
                 # Compute the short-ranged force
                 pot, fr = force(r, p_matrix)
+                fr /= r
                 U_s_r += pot
 
                 # Update the acceleration for i particles in each dimension


### PR DESCRIPTION
- Force in update_0D now computed correctly (normalization issue "fr /= r" analog to LCL calculation)
- Coulomb potential with pp alogithm usable again (changed to lowercase) -> broke uec.yaml example
- Remove calculation of RDF for UEC example as it is not necessary