### PR TITLE
Closed a couple of backticks in docstring

### DIFF
--- a/docs/theory/force_error.rst
+++ b/docs/theory/force_error.rst
@@ -1,3 +1,5 @@
+.. _force_error:
+
 ===========
 Force Error
 ===========

--- a/sarkas/processes.py
+++ b/sarkas/processes.py
@@ -593,28 +593,28 @@ class PreProcess(Process):
 
     def make_color_map(self, rcuts, alphas, chosen_alpha, chosen_rcut, total_force_error):
         """
-         Plot a color map of the total force error approximation.
+        Plot a color map of the total force error approximation.
 
-         Parameters
-         ----------
-         rcuts: numpy.ndarray
-             Cut off distances.
+        Parameters
+        ----------
+        rcuts: numpy.ndarray
+            Cut off distances.
 
-         alphas: numpy.ndarray
-             Ewald parameters.
+        alphas: numpy.ndarray
+            Ewald parameters.
 
-         chosen_alpha: float
-             Chosen Ewald parameter.
+        chosen_alpha: float
+            Chosen Ewald parameter.
 
-         chosen_rcut: float
-             Chosen cut off radius.
+        chosen_rcut: float
+            Chosen cut off radius.
 
-         total_force_error: numpy.ndarray
-             Force error matrix.
+        total_force_error: numpy.ndarray
+            Force error matrix.
 
         Raises
         ------
-            : DeprecationWarning
+          DeprecationWarning
 
         """
         warn(

--- a/sarkas/utilities/maths.py
+++ b/sarkas/utilities/maths.py
@@ -159,7 +159,7 @@ def betamp(m: int, p: int, alpha: float, kappa: float) -> float:
 def force_error_approx_pppm(potential):
     r"""
     Calculates the force error, :math:`\Delta F_{\rm pm}`, for the PPPM algorithm using approximations given in :cite:`Dharuman2017`.
-    The formula for :math:`\Delta F_{\rm pm}` can be found in :doc:`force_error`.
+    The formula for :math:`\Delta F_{\rm pm}` can be found in :ref:`force_error`.
 
     Parameters
     ----------
@@ -202,7 +202,7 @@ def force_error_approx_pppm(potential):
 def force_error_approx_pm(kappa: float, p: int, h: float, alpha: float):
     r"""
     Calculates the PM part of the force error, :math:`\Delta F_{\rm pm}`,  for a given value of the PPPM parameters.
-    The formula for :math:`\Delta F_{\rm pm}` can be found in :doc:`force_error`.
+    The formula for :math:`\Delta F_{\rm pm}` can be found in :ref:`force_error`.
 
     Parameters
     ----------

--- a/sarkas/utilities/maths.py
+++ b/sarkas/utilities/maths.py
@@ -158,18 +158,18 @@ def betamp(m: int, p: int, alpha: float, kappa: float) -> float:
 
 def force_error_approx_pppm(potential):
     r"""
-     Calculates the force error, :math:`\Delta F_{\rm {pm}}, for the PPPM algorithm using approximations given in :cite:`Dharuman2017`.
-     The formula for :math:`\Delta F_{\rm {pm}}` can be found in :ref:`force_error`.
+    Calculates the force error, :math:`\Delta F_{\rm pm}`, for the PPPM algorithm using approximations given in :cite:`Dharuman2017`.
+    The formula for :math:`\Delta F_{\rm pm}` can be found in :ref:`force_error`.
 
-     Parameters
-     ----------
-     potential: :class:`sarkas.potentials.core.Potential`
-        Potential class with all the required information.
+    Parameters
+    ----------
+    potential: :class:`sarkas.potentials.core.Potential`
+       Potential class with all the required information.
 
-     Returns
-     -------
+    Returns
+    -------
     tot_force_error: float
-        Total force error given by the L2 norm of the PP and PM force errors.
+       Total force error given by the L2 norm of the PP and PM force errors.
 
     pppm_pm_err: float
         PM force error.
@@ -201,8 +201,8 @@ def force_error_approx_pppm(potential):
 
 def force_error_approx_pm(kappa: float, p: int, h: float, alpha: float):
     r"""
-    Calculates the PM part of the force error, :math:`\Delta F_{\rm {pm}},  for a given value of the PPPM parameters.
-    The formula for :math:`\Delta F_{\rm {pm}}` can be found in :ref:`force_error`.
+    Calculates the PM part of the force error, :math:`\Delta F_{\rm pm}`,  for a given value of the PPPM parameters.
+    The formula for :math:`\Delta F_{\rm pm}` can be found in :ref:`force_error`.
 
     Parameters
     ----------

--- a/sarkas/utilities/maths.py
+++ b/sarkas/utilities/maths.py
@@ -159,7 +159,7 @@ def betamp(m: int, p: int, alpha: float, kappa: float) -> float:
 def force_error_approx_pppm(potential):
     r"""
     Calculates the force error, :math:`\Delta F_{\rm pm}`, for the PPPM algorithm using approximations given in :cite:`Dharuman2017`.
-    The formula for :math:`\Delta F_{\rm pm}` can be found in :ref:`force_error`.
+    The formula for :math:`\Delta F_{\rm pm}` can be found in :doc:`force_error`.
 
     Parameters
     ----------
@@ -202,7 +202,7 @@ def force_error_approx_pppm(potential):
 def force_error_approx_pm(kappa: float, p: int, h: float, alpha: float):
     r"""
     Calculates the PM part of the force error, :math:`\Delta F_{\rm pm}`,  for a given value of the PPPM parameters.
-    The formula for :math:`\Delta F_{\rm pm}` can be found in :ref:`force_error`.
+    The formula for :math:`\Delta F_{\rm pm}` can be found in :doc:`force_error`.
 
     Parameters
     ----------


### PR DESCRIPTION
Backticks were not closed in the docstring of a couple of methods in `sarkas.utilities.maths`  which were creating WARNINGs like `Inline interpreted text or phrase reference start-string without end-string.` during the website's build .

In fact, in the website the math formulas did not show up. 
![image](https://user-images.githubusercontent.com/18087952/226057714-2bccad07-febe-4357-960e-4d7ff4bf74a5.png)
